### PR TITLE
[feat] shader hot reload bug fix

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.cpp
@@ -160,7 +160,9 @@ void FStaticMeshRenderPass::PrepareRender()
 void FStaticMeshRenderPass::PrepareRenderState(const std::shared_ptr<FEditorViewportClient>& Viewport) 
 {
     const EViewModeIndex ViewMode = Viewport->GetViewMode();
-    
+
+    ChangeViewMode(ViewMode);
+
     Graphics->DeviceContext->VSSetShader(VertexShader, nullptr, 0);
     Graphics->DeviceContext->IASetInputLayout(InputLayout);
 
@@ -179,7 +181,6 @@ void FStaticMeshRenderPass::PrepareRenderState(const std::shared_ptr<FEditorView
     BufferManager->BindConstantBuffer(TEXT("FLightInfoBuffer"), 0, EShaderStage::Vertex);
     BufferManager->BindConstantBuffer(TEXT("FMaterialConstants"), 1, EShaderStage::Vertex);
 
-    ChangeViewMode(ViewMode);
 
     // Rasterizer
     if (ViewMode == EViewModeIndex::VMI_Wireframe)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Windows/D3D11RHI/DXDShaderManager.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Windows/D3D11RHI/DXDShaderManager.cpp
@@ -53,8 +53,8 @@ void FDXDShaderManager::UpdateShaderIfOutdated(const std::wstring Key, const std
         ShaderTimeStamps.Add(Key, currentTime);
         return;
     }
-    if (*FoundTime == currentTime) // Map에 저장된 마지막 수정 타임이 현재와 똑같을 경우
-        return;
+    //if (*FoundTime == currentTime) // Map에 저장된 마지막 수정 타임이 현재와 똑같을 경우
+    //    return;
 
     if (IsVertexShader)
     {
@@ -62,6 +62,7 @@ void FDXDShaderManager::UpdateShaderIfOutdated(const std::wstring Key, const std
         if (VertexShaders.Contains(Key)) { VertexShaders[Key]->Release(); VertexShaders[Key] = nullptr; }
         if (InputLayouts.Contains(Key)) { InputLayouts[Key]->Release();    InputLayouts[Key] = nullptr; }
 
+        ShaderTimeStamps[Key] = currentTime;
         (Defines)
             ? AddVertexShaderAndInputLayout(Key, FilePath, EntryPoint, Layout, LayoutSize, Defines)
             : AddVertexShaderAndInputLayout(Key, FilePath, EntryPoint, Layout, LayoutSize);


### PR DESCRIPTION
shader hot reload #include파일에 대해 적용되지 않던 버그 수정

## 주요 변경사항

1.  #include된 파일이 hot reload 되지 않던 이유

![image](https://github.com/user-attachments/assets/77889b42-3af2-4c0d-aa21-5b9a1e8b269b)
렌더가 끝날때 ReloadAllShaders 함수를 호출합니다.

![image](https://github.com/user-attachments/assets/12c46a6e-d165-43a9-9183-4aae8b23bb25)
ReloadAllShaders 함수는 IsOutdatedWithDependency 함수에서

![image](https://github.com/user-attachments/assets/b95fb2b8-0578-4bcb-a6e4-f8e217f9c712)
Shader의 변경사항을 감지해(파일 수정 시간) 갱신할지 말지를 체크합니다.

![image](https://github.com/user-attachments/assets/f1ef707b-6cb2-44af-848a-e286f5234019)
그리고 UpdateShaderIfOutdated 함수에서 Release와 Create를 진행합니다.

그런데 이 때 기존에는 UpdateShaderIfOutdated 함수 내의
![image](https://github.com/user-attachments/assets/17bd8cf2-e9de-4243-b29e-1664a452b12a)

에서 한번 더 파일 수정 시간을 체크해주고 있었습니다.
그런데, #include되는 Light.hlsl 같은 파일은 따로 Key로서 등록되어 있지 않고
Light.hlsl 파일이 변경될 경우 파일 변경 시간만 체크됩니다.
StaticMeshVertexShader.hlsl이나 StaticMeshPixelShader.hlsl은 Key로서 등록되어 있지만 파일 변경은 되고 있지 않아StaticMeshVertexShader.hlsl, StaticMeshPixelShader.hlsl 파일을 재컴파일 해주어야합니다.

즉, 파일변경시간이 동일해도 재컴파일 할 수 있도록 위의 if문을 주석 처리하였습니다.


2. StaticMeshVertexShader.hlsl Hot Reload시 컴파일 에러 발생 문제
하지만 또 다른 문제가 발생했습니다. Light.hlsl의 변경사항을 반영하여 HotReload를 진행하자,
PixelShader에서는 문제 없었지만 VertexShader에서 컴파일 에러를 뱉었습니다.

![image](https://github.com/user-attachments/assets/e8da3405-faa6-4251-a6a0-b01de6fe52c3)
그래서 에러 발생 코드 위에서 디버깅을 시도한 결과 새로운 포인터 주소를 받아야함에도 불구하고
  VS ptr = 0000028FF7F90680  |  PS ptr = 0000028FF810AF20
  VS ptr = 0000028FF7F90680  |  PS ptr = 0000028FFA505C90

VS의 ptr이 동일함을 발견할 수 있었습니다. (PS ptr은 Shader Reload시 변경되었습니다.)

즉, VertexShader에 새로운 쉐이더가 바인딩 되지 않던 문제였습니다.
VertexShader와 PixelShader에 새로운 쉐이더가 바인딩 되는 곳은 ChangeViewMode입니다.
![image](https://github.com/user-attachments/assets/27eff4b7-2623-412e-a4e8-a7d27c6f2e6d)

이 ChangeViewMode함수가
![image](https://github.com/user-attachments/assets/14e54f50-8905-445d-88fc-7876e1e34835)


이후에 실행되고 있었기 때문에 
![image](https://github.com/user-attachments/assets/c6528524-b0ae-40ae-932b-6eb8eec9f0d4)
PrepareRenderState 함수 최상단으로 옮겼습니다.