### PR TITLE
Refactor: OBJ 바이너리 주석해제 및 변수 몇개 추가

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/FLoaderOBJ.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/FLoaderOBJ.cpp
@@ -564,7 +564,7 @@ OBJ::FStaticMeshRenderData* FManagerOBJ::LoadObjStaticMeshAsset(const FString& P
         return nullptr;
     }
 
-    // SaveStaticMeshToBinary(BinaryPath, *NewStaticMesh); // TODO: refactoring 끝나면 활성화하기
+    SaveStaticMeshToBinary(BinaryPath, *NewStaticMesh); 
     ObjStaticMeshMap.Add(PathFileName, NewStaticMesh);
     return NewStaticMesh;
 }
@@ -623,19 +623,25 @@ bool FManagerOBJ::SaveStaticMeshToBinary(const FWString& FilePath, const OBJ::FS
         File.write(reinterpret_cast<const char*>(&Material.Specular), sizeof(Material.Specular));
         File.write(reinterpret_cast<const char*>(&Material.Ambient), sizeof(Material.Ambient));
         File.write(reinterpret_cast<const char*>(&Material.Emissive), sizeof(Material.Emissive));
+        
         File.write(reinterpret_cast<const char*>(&Material.SpecularScalar), sizeof(Material.SpecularScalar));
         File.write(reinterpret_cast<const char*>(&Material.DensityScalar), sizeof(Material.DensityScalar));
         File.write(reinterpret_cast<const char*>(&Material.TransparencyScalar), sizeof(Material.TransparencyScalar));
+        File.write(reinterpret_cast<const char*>(&Material.BumpMultiplier), sizeof(Material.BumpMultiplier));
         File.write(reinterpret_cast<const char*>(&Material.IlluminanceModel), sizeof(Material.IlluminanceModel));
 
         Serializer::WriteFString(File, Material.DiffuseTextureName);
         Serializer::WriteFWString(File, Material.DiffuseTexturePath);
+        
         Serializer::WriteFString(File, Material.AmbientTextureName);
         Serializer::WriteFWString(File, Material.AmbientTexturePath);
+        
         Serializer::WriteFString(File, Material.SpecularTextureName);
         Serializer::WriteFWString(File, Material.SpecularTexturePath);
+        
         Serializer::WriteFString(File, Material.BumpTextureName);
         Serializer::WriteFWString(File, Material.BumpTexturePath);
+        
         Serializer::WriteFString(File, Material.AlphaTextureName);
         Serializer::WriteFWString(File, Material.AlphaTexturePath);
     }
@@ -706,18 +712,25 @@ bool FManagerOBJ::LoadStaticMeshFromBinary(const FWString& FilePath, OBJ::FStati
         File.read(reinterpret_cast<char*>(&Material.Specular), sizeof(Material.Specular));
         File.read(reinterpret_cast<char*>(&Material.Ambient), sizeof(Material.Ambient));
         File.read(reinterpret_cast<char*>(&Material.Emissive), sizeof(Material.Emissive));
+        
         File.read(reinterpret_cast<char*>(&Material.SpecularScalar), sizeof(Material.SpecularScalar));
         File.read(reinterpret_cast<char*>(&Material.DensityScalar), sizeof(Material.DensityScalar));
         File.read(reinterpret_cast<char*>(&Material.TransparencyScalar), sizeof(Material.TransparencyScalar));
+        File.read(reinterpret_cast<char*>(&Material.BumpMultiplier), sizeof(Material.BumpMultiplier));
         File.read(reinterpret_cast<char*>(&Material.IlluminanceModel), sizeof(Material.IlluminanceModel));
+        
         Serializer::ReadFString(File, Material.DiffuseTextureName);
         Serializer::ReadFWString(File, Material.DiffuseTexturePath);
+        
         Serializer::ReadFString(File, Material.AmbientTextureName);
         Serializer::ReadFWString(File, Material.AmbientTexturePath);
+        
         Serializer::ReadFString(File, Material.SpecularTextureName);
         Serializer::ReadFWString(File, Material.SpecularTexturePath);
+        
         Serializer::ReadFString(File, Material.BumpTextureName);
         Serializer::ReadFWString(File, Material.BumpTexturePath);
+        
         Serializer::ReadFString(File, Material.AlphaTextureName);
         Serializer::ReadFWString(File, Material.AlphaTexturePath);
 

--- a/EngineSIU/EngineSIU/Saved/AutoSaves.scene
+++ b/EngineSIU/EngineSIU/Saved/AutoSaves.scene
@@ -9,8 +9,8 @@
                     "ComponentClass": "UStaticMeshComponent",
                     "ComponentID": "StaticMeshComponent_0",
                     "Properties": {
-                        "AABB_max": "X=1.287 Y=1.199 Z=2.555",
-                        "AABB_min": "X=-1.287 Y=-1.199 Z=-0.000",
+                        "AABB_max": "X=1.000 Y=-0.000 Z=1.000",
+                        "AABB_min": "X=0.000 Y=-1.000 Z=0.000",
                         "ComponentClass": "UStaticMeshComponent",
                         "ComponentName": "StaticMeshComponent_0",
                         "ComponentOwner": "ACube_91",
@@ -18,7 +18,7 @@
                         "RelativeLocation": "X=34.849 Y=0.000 Z=0.000",
                         "RelativeRotation": "Pitch=-0.000 Yaw=0.000 Roll=33.804",
                         "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "StaticMeshPath": "Contents/Reference/Reference.obj",
+                        "StaticMeshPath": "Contents/Cube/cube-tex.obj",
                         "bAutoActive": "true",
                         "bIsActive": "true",
                         "m_Type": ""
@@ -26,61 +26,6 @@
                 }
             ],
             "RootComponentID": "StaticMeshComponent_0"
-        },
-        {
-            "ActorClass": "ASpotLight",
-            "ActorID": "ASpotLight_93",
-            "ActorLabel": "OBJ_SPOTLIGHT_93",
-            "Components": [
-                {
-                    "ComponentClass": "USpotLightComponent",
-                    "ComponentID": "USpotLightComponent_0",
-                    "Properties": {
-                        "AABB_Max": "X=1.000 Y=1.000 Z=0.100",
-                        "AABB_Min": "X=-1.000 Y=-1.000 Z=-0.100",
-                        "Attenuation": "20.000000",
-                        "ComponentClass": "USpotLightComponent",
-                        "ComponentName": "USpotLightComponent_0",
-                        "ComponentOwner": "ASpotLight_93",
-                        "ComponentOwnerClass": "ASpotLight",
-                        "Direction": "X=1.000 Y=0.000 Z=0.000",
-                        "InnerRad": "0.261800",
-                        "Intensity": "1000.000000",
-                        "LightColor": "R=1.000 G=1.000 B=1.000 A=1.000",
-                        "OuterRad": "0.523600",
-                        "Position": "X=0.000 Y=0.000 Z=0.000",
-                        "Radius": "30.000000",
-                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "Type": "2",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                },
-                {
-                    "ComponentClass": "UBillboardComponent",
-                    "ComponentID": "UBillboardComponent_0",
-                    "Properties": {
-                        "AABB_max": "X=0.000 Y=0.000 Z=0.000",
-                        "AABB_min": "X=0.000 Y=0.000 Z=0.000",
-                        "BufferKey": "Assets/Editor/Icon/SpotLight_64x.png",
-                        "ComponentClass": "UBillboardComponent",
-                        "ComponentName": "UBillboardComponent_0",
-                        "ComponentOwner": "ASpotLight_93",
-                        "ComponentOwnerClass": "ASpotLight",
-                        "FinalIndexU": "0.000000",
-                        "FinalIndexV": "0.000000",
-                        "RelativeLocation": "X=0.000 Y=6.816 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=18.908 Roll=-0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.682 Z=1.000",
-                        "bAutoActive": "true",
-                        "bIsActive": "true",
-                        "m_Type": "UBillboardComponent"
-                    }
-                }
-            ],
-            "RootComponentID": "UBillboardComponent_0"
         },
         {
             "ActorClass": "APointLight",
@@ -124,7 +69,83 @@
                         "FinalIndexU": "0.000000",
                         "FinalIndexV": "0.000000",
                         "RelativeLocation": "X=0.000 Y=-14.777 Z=1.635",
+                        "RelativeRotation": "Pitch=6.200 Yaw=-6.200 Roll=19.700",
+                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
+                        "bAutoActive": "true",
+                        "bIsActive": "true",
+                        "m_Type": "UBillboardComponent"
+                    }
+                }
+            ],
+            "RootComponentID": "UBillboardComponent_0"
+        },
+        {
+            "ActorClass": "ACube",
+            "ActorID": "ACube_102",
+            "ActorLabel": "OBJ_CUBE_102",
+            "Components": [
+                {
+                    "ComponentClass": "UStaticMeshComponent",
+                    "ComponentID": "StaticMeshComponent_0",
+                    "Properties": {
+                        "AABB_max": "X=1.287 Y=1.199 Z=2.555",
+                        "AABB_min": "X=-1.287 Y=-1.199 Z=-0.000",
+                        "ComponentClass": "UStaticMeshComponent",
+                        "ComponentName": "StaticMeshComponent_0",
+                        "ComponentOwner": "ACube_102",
+                        "ComponentOwnerClass": "ACube",
+                        "RelativeLocation": "X=0.000 Y=-8.063 Z=3.574",
                         "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
+                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
+                        "StaticMeshPath": "Contents/Reference/Reference.obj",
+                        "bAutoActive": "true",
+                        "bIsActive": "true",
+                        "m_Type": ""
+                    }
+                }
+            ],
+            "RootComponentID": "StaticMeshComponent_0"
+        },
+        {
+            "ActorClass": "ADirectionalLight",
+            "ActorID": "ADirectionalLight_104",
+            "ActorLabel": "OBJ_DIRECTIONALLGIHT_104",
+            "Components": [
+                {
+                    "ComponentClass": "UDirectionalLightComponent",
+                    "ComponentID": "UDirectionalLightComponent_0",
+                    "Properties": {
+                        "AABB_Max": "X=1.000 Y=1.000 Z=0.100",
+                        "AABB_Min": "X=-1.000 Y=-1.000 Z=-0.100",
+                        "ComponentClass": "UDirectionalLightComponent",
+                        "ComponentName": "UDirectionalLightComponent_0",
+                        "ComponentOwner": "ADirectionalLight_104",
+                        "ComponentOwnerClass": "ADirectionalLight",
+                        "Direction": "X=-0.000 Y=-0.000 Z=-1.000",
+                        "Intensity": "10.000000",
+                        "LightColor": "R=1.000 G=1.000 B=1.000 A=1.000",
+                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
+                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
+                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
+                        "bAutoActive": "true",
+                        "bIsActive": "true"
+                    }
+                },
+                {
+                    "ComponentClass": "UBillboardComponent",
+                    "ComponentID": "UBillboardComponent_0",
+                    "Properties": {
+                        "AABB_max": "X=0.000 Y=0.000 Z=0.000",
+                        "AABB_min": "X=0.000 Y=0.000 Z=0.000",
+                        "BufferKey": "Assets/Editor/Icon/DirectionalLight_64x.png",
+                        "ComponentClass": "UBillboardComponent",
+                        "ComponentName": "UBillboardComponent_0",
+                        "ComponentOwner": "ADirectionalLight_104",
+                        "ComponentOwnerClass": "ADirectionalLight",
+                        "FinalIndexU": "0.000000",
+                        "FinalIndexV": "0.000000",
+                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
+                        "RelativeRotation": "Pitch=154.500 Yaw=-25.300 Roll=-126.900",
                         "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
                         "bAutoActive": "true",
                         "bIsActive": "true",


### PR DESCRIPTION
이 풀 리퀘스트는 `FLoaderOBJ` 파일의 기능을 다시 활성화하고 재질 직렬화(material serialization)를 확장하는 업데이트와, `AutoSaves.scene` 파일의 씬 컴포넌트 및 라이팅 구성을 조정하는 수정을 포함합니다. 이러한 변경 사항들은 에셋 처리와 씬 표현을 개선하는 것을 목표로 합니다.

### 정적 메시(Static Mesh) 에셋 처리를 위한 `FLoaderOBJ` 업데이트:

*   `LoadObjStaticMeshAsset` 함수에서 이전에 주석 처리되었던 `SaveStaticMeshToBinary` 함수 호출을 다시 활성화했습니다. 이를 통해 정적 메시가 로딩 과정 중에 바이너리 파일로 저장되도록 합니다.
*   `SaveStaticMeshToBinary` 및 `LoadStaticMeshFromBinary` 함수에서 재질 직렬화를 확장하여 `BumpMultiplier`와 같은 추가 속성을 포함하고, 가독성 향상을 위해 공백을 추가했습니다. [[관련 코드 변경 1]](diffhunk://#diff-c51d78e4c0fe014819b8f103fabe09d2ad9982bd772ec4b8caf3663cc01a62f6R626-R644) [[관련 코드 변경 2]](diffhunk://#diff-c51d78e4c0fe014819b8f103fabe09d2ad9982bd772ec4b8caf3663cc01a62f6R715-R733)
