### PR TITLE
Fix: 세이브, Duplicate 버그 해결

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Plane.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Plane.cpp
@@ -1,0 +1,20 @@
+#include "Plane.h"
+
+#include "Misc/Parse.h"
+
+
+FString FPlane::ToString() const
+{
+    return FString::Printf(TEXT("X=%3.3f Y=%3.3f Z=%3.3f W=%3.3f"), X, Y, Z, W);
+}
+
+bool FPlane::InitFromString(const FString& InSourceString)
+{
+    X = Y = Z = W = 0;
+    
+     const bool bSuccessful = FParse::Value(*InSourceString, TEXT("X="), X) && 
+           FParse::Value(*InSourceString, TEXT("Y="), Y) && 
+           FParse::Value(*InSourceString, TEXT("Z="), Z) &&
+           FParse::Value(*InSourceString, TEXT("W="), W);
+    return bSuccessful;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Plane.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Plane.h
@@ -1,0 +1,225 @@
+#pragma once
+
+#include "Vector.h"       // 기본 FVector 정의
+#include "MathUtility.h"  // FMath 함수 및 상수
+#include "Serialization/Archive.h" // 직렬화
+
+/**
+ * 3차원 평면을 위한 구조체입니다.
+ * 평면 방정식 계수를 법선 벡터는 X,Y,Z로, D 성분은 W로 저장합니다 (Ax+By+Cz+D=0).
+ * 참고: 법선 성분(X, Y, Z)을 위해 FVector로부터 상속받습니다.
+ */
+struct FPlane : public FVector
+{
+public:
+	/** 평면 방정식의 D 성분 (Ax+By+Cz+D=0) */
+	float W;
+
+public:
+	/** 기본 생성자 (평면을 Z=0 평면으로 설정, Normal=(0,0,1), W=0). */
+	FPlane();
+
+	/**
+	 * 생성자.
+	 * @param V 평면의 법선 벡터 성분. V가 정규화되었다고 가정합니다.
+	 * @param InW 평면 방정식의 D 성분.
+	 */
+	FPlane(const FVector& V, float InW);
+
+	/**
+	 * 구성 요소로부터의 생성자.
+	 * @param InX 법선 벡터의 X-성분.
+	 * @param InY 법선 벡터의 Y-성분.
+	 * @param InZ 법선 벡터의 Z-성분.
+	 * @param InW 평면 방정식의 D 성분.
+	 * 법선(InX, InY, InZ)이 정규화되었다고 가정합니다.
+	 */
+	FPlane(float InX, float InY, float InZ, float InW);
+
+	/**
+	 * 점과 법선 벡터로부터의 생성자.
+	 * 생성자는 법선 벡터를 정규화합니다.
+	 * @param InPoint 평면 위의 한 점.
+	 * @param InNormal 평면에 대한 법선 벡터.
+	 */
+	FPlane(const FVector& InPoint, const FVector& InNormal);
+
+	/**
+	 * 동일 선상에 있지 않은 세 점으로부터의 생성자.
+	 * 법선 벡터를 계산하고, 정규화하며, W를 계산합니다.
+	 * @param A 평면 위의 첫 번째 점.
+	 * @param B 평면 위의 두 번째 점.
+	 * @param C 평면 위의 세 번째 점.
+	 */
+	FPlane(const FVector& A, const FVector& B, const FVector& C);
+
+	//~ Begin FVector Interface (기본값은 법선의 X, Y, Z에 적합함)
+	// 연산자 오버로딩 (+, -, *, / 와 FVector 또는 float)은 법선 부분에 대해 상속됩니다.
+	// 내적/외적 (| ^)은 법선 부분에 대해 상속됩니다.
+	// Length/Normalize 메서드는 법선 부분에 대해 상속됩니다.
+	// 주의: FPlane에 대해 Normalize()를 호출하면 법선(X,Y,Z)은 정규화되지만 W 값은 올바르게 조정되지 않습니다. 대신 FPlane::Normalize 메서드를 사용해야 합니다.
+	//~ End FVector Interface
+
+public:
+	/**
+	 * 점에서 평면까지의 부호 있는 거리를 계산합니다.
+	 * 평면이 정규화되었다고 가정합니다 (법선 벡터는 단위 길이).
+	 * @param P 테스트할 점.
+	 * @return 부호 있는 거리. 점이 법선 방향에 있으면 양수, 그렇지 않으면 음수.
+	 */
+	float PlaneDot(const FVector& P) const;
+
+	/**
+	 * 평면 방정식(법선 벡터와 W 성분)을 정규화합니다.
+	 * 법선 벡터(X, Y, Z)가 단위 길이임을 보장하고 W를 그에 맞게 조정합니다.
+	 * @param Tolerance 정규화를 위한 최소 법선 길이 제곱 값.
+	 * @return 정규화에 성공하면 true, 그렇지 않으면 false.
+	 */
+	bool Normalize(float Tolerance = SMALL_NUMBER);
+
+	/**
+	 * 평면의 정규화된 복사본을 가져옵니다.
+	 * @param Tolerance 정규화를 위한 최소 법선 길이 제곱 값.
+	 * @return 평면의 정규화된 복사본.
+	 */
+	FPlane GetNormalized(float Tolerance = SMALL_NUMBER) const;
+
+	/**
+	 * 두 평면이 오차 범위 내에서 같은지 확인합니다. 법선과 W를 확인합니다.
+	 * @param V 다른 평면.
+	 * @param Tolerance 오차 허용 범위.
+	 * @return 평면들이 오차 범위 내에서 같으면 true, 그렇지 않으면 false.
+	 */
+	bool Equals(const FPlane& V, float Tolerance = KINDA_SMALL_NUMBER) const;
+
+	/** 동등 연산자. */
+	bool operator==(const FPlane& V) const;
+
+	/** 부등 연산자. */
+	bool operator!=(const FPlane& V) const;
+
+	/**
+	 * 평면의 텍스트 표현을 가져옵니다.
+	 * @return 평면을 설명하는 텍스트.
+	 */
+	FString ToString() const;
+
+    
+    bool InitFromString(const FString& InSourceString);
+
+
+	// 직렬화를 위한 friend
+	friend FArchive& operator<<(FArchive& Ar, FPlane& P);
+};
+
+
+// 인라인 구현
+
+inline FPlane::FPlane()
+	: FVector(0.f, 0.f, 1.f) // 기본 법선 (0,0,1)
+	, W(0.f)                 // 기본 D=0
+{
+}
+
+inline FPlane::FPlane(const FVector& V, float InW)
+	: FVector(V) // 법선 X, Y, Z 설정
+	, W(InW)     // W 설정
+{
+	// 나중에 거리 함수에 필요하다면 호출자가 V를 이미 정규화했다고 가정합니다.
+}
+
+inline FPlane::FPlane(float InX, float InY, float InZ, float InW)
+	: FVector(InX, InY, InZ) // 법선 X, Y, Z 설정
+	, W(InW)                 // W 설정
+{
+	// 필요하다면 호출자가 (InX, InY, InZ)를 이미 정규화했다고 가정합니다.
+}
+
+inline FPlane::FPlane(const FVector& InPoint, const FVector& InNormal)
+{
+	// 법선 벡터 정규화
+	FVector NormalizedNormal = InNormal.GetSafeNormal();
+	X = NormalizedNormal.X;
+	Y = NormalizedNormal.Y;
+	Z = NormalizedNormal.Z;
+
+	// D = -(Normal dot Point) 계산
+	W = -(NormalizedNormal | InPoint);
+}
+
+inline FPlane::FPlane(const FVector& A, const FVector& B, const FVector& C)
+{
+	// 법선 벡터 계산: (B-A) 외적 (C-A)
+	FVector Normal = FVector::CrossProduct(B - A, C - A);
+
+	// 법선 벡터 정규화
+	FVector NormalizedNormal = Normal.GetSafeNormal();
+	X = NormalizedNormal.X;
+	Y = NormalizedNormal.Y;
+	Z = NormalizedNormal.Z;
+
+	// 점 중 하나를 사용하여 D = -(Normal dot A) 계산
+	W = -(NormalizedNormal | A);
+}
+
+inline float FPlane::PlaneDot(const FVector& P) const
+{
+	// 이 평면이 이미 정규화되었다고 가정합니다!
+	// Ax + By + Cz + D 계산
+	// 법선 부분(X,Y,Z)과 P의 내적에 FVector::operator| 사용
+	return (static_cast<const FVector&>(*this) | P) + W;
+    // 또는 명시적으로: return X * P.X + Y * P.Y + Z * P.Z + W;
+}
+
+inline bool FPlane::Normalize(float Tolerance)
+{
+	const float NormalLengthSq = X * X + Y * Y + Z * Z; // FVector::LengthSquared()
+
+	if (NormalLengthSq > Tolerance)
+	{
+		const float NormalLength = FMath::Sqrt(NormalLengthSq);
+		const float InvNormalLength = 1.0f / NormalLength;
+		X *= InvNormalLength;
+		Y *= InvNormalLength;
+		Z *= InvNormalLength;
+		W *= InvNormalLength; // W 성분도 조정해야 합니다!
+		return true;
+	}
+	// 선택 사항: 정규화 실패 시 기본 평면으로 설정?
+	// X = Y = 0.f; Z = 1.f; W = 0.f;
+	return false;
+}
+
+inline FPlane FPlane::GetNormalized(float Tolerance) const
+{
+	FPlane Result = *this;
+	Result.Normalize(Tolerance);
+	return Result;
+}
+
+inline bool FPlane::Equals(const FPlane& V, float Tolerance) const
+{
+    return (FMath::Abs(X - V.X) < Tolerance) && (FMath::Abs(Y - V.Y) < Tolerance) && (FMath::Abs(Z - V.Z) < Tolerance) && (FMath::Abs(W - V.W) < Tolerance);
+}
+
+inline bool FPlane::operator==(const FPlane& V) const
+{
+    return (X == V.X) && (Y == V.Y) && (Z == V.Z) && (W == V.W);
+}
+
+inline bool FPlane::operator!=(const FPlane& V) const
+{
+	return (X != V.X) || (Y != V.Y) || (Z != V.Z) || (W != V.W);
+}
+
+
+
+// 직렬화는 기본 클래스 부분과 W 부분을 처리해야 합니다
+inline FArchive& operator<<(FArchive& Ar, FPlane& P)
+{
+	// FVector 부분 (X, Y, Z)을 먼저 직렬화
+	Ar << static_cast<FVector&>(P);
+	// 그런 다음 W 성분 직렬화
+	Ar << P.W;
+	return Ar;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
@@ -6,10 +6,11 @@ extern FEngineLoop GEngineLoop;
 
 class UClass;
 class UWorld;
-
+class AActor;
 
 class UObject
 {
+    friend class AActor;
 private:
     UObject(const UObject&) = delete;
     UObject& operator=(const UObject&) = delete;
@@ -34,6 +35,10 @@ private:
     UClass* ClassPrivate = nullptr;
     UObject* OuterPrivate = nullptr;
 
+    
+    // FName을 키값으로 넣어주는 컨테이너를 모두 업데이트 해야합니다.
+    void SetFName(const FName& InName) { NamePrivate = InName; }
+
 public:
     UObject();
     virtual ~UObject() = default;
@@ -46,6 +51,7 @@ public:
 
     FName GetFName() const { return NamePrivate; }
     FString GetName() const { return NamePrivate.ToString(); }
+
 
     uint32 GetUUID() const { return UUID; }
     uint32 GetInternalIndex() const { return InternalIndex; }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.cpp
@@ -10,8 +10,13 @@ UObject* AActor::Duplicate(UObject* InOuter)
     NewActor->bTickInEditor = bTickInEditor;
     // 기본적으로 있던 컴포넌트 제거
     TSet CopiedComponents = NewActor->OwnedComponents;
+
+    //임시용 디폴트 컴포넌트 이름 저장
+    //TODO: 디퐅트 컴포넌트를 삭제하지 않고 그 컴포넌트에 프로퍼티를 복사하는 방법으로 변경 필요
+    TArray<FName> DefaultCopiedComponentNames;
     for (UActorComponent* Components : CopiedComponents)
     {
+        DefaultCopiedComponentNames.Add(Components->GetFName());
         Components->DestroyComponent();
     }
     NewActor->OwnedComponents.Empty();
@@ -25,10 +30,20 @@ UObject* AActor::Duplicate(UObject* InOuter)
 
     for (UActorComponent* Component : OwnedComponents)
     {
-        UActorComponent* NewComponent = Cast<UActorComponent>(Component->Duplicate(InOuter));
+
+        UActorComponent* NewComponent = Cast<UActorComponent>(Component->Duplicate(NewActor));
         NewComponent->OwnerPrivate = NewActor;
         NewActor->OwnedComponents.Add(NewComponent);
 
+        //디폴트 컴포넌트 이름 동일하게 
+        for (const auto DefaultCopiedName : DefaultCopiedComponentNames)
+        {
+            if (DefaultCopiedName == Component->GetFName())
+            {
+                NewComponent->SetFName(DefaultCopiedName);
+            }
+        }
+  
         // RootComponent 설정
         if (RootComponent == Component)
         {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.cpp
@@ -132,6 +132,13 @@ void FBillboardRenderPass::CreateShader()
     PixelShader = ShaderManager->GetPixelShaderByKey(L"PixelBillboardShader");
 }
 
+void FBillboardRenderPass::UpdateShader()
+{
+    VertexShader = ShaderManager->GetVertexShaderByKey(L"VertexBillboardShader");
+    InputLayout = ShaderManager->GetInputLayoutByKey(L"VertexBillboardShader");
+    PixelShader = ShaderManager->GetPixelShaderByKey(L"PixelBillboardShader");
+}
+
 void FBillboardRenderPass::ReleaseShader()
 {
 }
@@ -142,6 +149,8 @@ void FBillboardRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& 
 
     FRenderTargetRHI* RenderTargetRHI = ViewportResource->GetRenderTarget(ResourceType);
     Graphics->DeviceContext->OMSetRenderTargets(1, &RenderTargetRHI->RTV, ViewportResource->GetDepthStencilView());
+
+    UpdateShader();
 
     PrepareTextureShader();
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.h
@@ -46,6 +46,7 @@ public:
         ID3D11ShaderResourceView* _TextureSRV, ID3D11SamplerState* _SamplerState) const;
 
     void CreateShader();
+    void UpdateShader();
     void ReleaseShader();
 
 protected:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.cpp
@@ -52,6 +52,12 @@ void FFogRenderPass::CreateShader()
     PixelShader = ShaderManager->GetPixelShaderByKey(L"FogPixelShader");
 }
 
+void FFogRenderPass::UpdateShader()
+{
+    VertexShader = ShaderManager->GetVertexShaderByKey(L"FogVertexShader");
+    PixelShader = ShaderManager->GetPixelShaderByKey(L"FogPixelShader");
+}
+
 void FFogRenderPass::ReleaseShader()
 {
 }
@@ -112,6 +118,8 @@ void FFogRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Viewpo
 
     Graphics->DeviceContext->PSSetShaderResources(static_cast<UINT>(EShaderSRVSlot::SRV_SceneDepth), 1, &ViewportResource->GetDepthStencilSRV());
     
+    UpdateShader();
+
     PrepareRenderState();
     
     for (const auto& Fog : FogComponents)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.h
@@ -28,6 +28,7 @@ public:
 
     // Fog 렌더링용 셰이더 생성 및 입력 레이아웃 설정
     void CreateShader();
+    void UpdateShader();
     void ReleaseShader();
 
     void PrepareRenderState();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.cpp
@@ -76,6 +76,13 @@ void FGizmoRenderPass::CreateShader()
     PixelShader = ShaderManager->GetPixelShaderByKey(L"GizmoPixelShader");
 }
 
+void FGizmoRenderPass::UpdateShader()
+{
+    VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+    InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+    PixelShader = ShaderManager->GetPixelShaderByKey(L"GizmoPixelShader");
+}
+
 void FGizmoRenderPass::ReleaseShader()
 {
 }
@@ -92,7 +99,7 @@ void FGizmoRenderPass::ClearRenderArr()
 void FGizmoRenderPass::PrepareRenderState() const
 {
     Graphics->DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    
+
     Graphics->DeviceContext->VSSetShader(VertexShader, nullptr, 0);
     Graphics->DeviceContext->PSSetShader(PixelShader, nullptr, 0);
     Graphics->DeviceContext->IASetInputLayout(InputLayout);
@@ -191,6 +198,8 @@ void FGizmoRenderPass::RenderGizmoComponent(UGizmoBaseComponent* GizmoComp, cons
     {
         return;
     }
+
+    UpdateShader();
 
     PrepareRenderState();
     

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.h
@@ -33,6 +33,7 @@ public:
     void RenderGizmoComponent(UGizmoBaseComponent* GizmoComp, const std::shared_ptr<FEditorViewportClient>& Viewport);
 
     void CreateShader();
+    void UpdateShader();
     void ReleaseShader();
 
     void CreateBuffer();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.cpp
@@ -57,6 +57,12 @@ void FLineRenderPass::CreateShader()
     PixelLineShader = ShaderManager->GetPixelShaderByKey(L"PixelLineShader");
 }
 
+void FLineRenderPass::UpdateShader()
+{
+    VertexLineShader = ShaderManager->GetVertexShaderByKey(L"VertexLineShader");
+    PixelLineShader = ShaderManager->GetPixelShaderByKey(L"PixelLineShader");
+}
+
 void FLineRenderPass::PrepareLineShader() const
 {
     Graphics->DeviceContext->VSSetShader(VertexLineShader, nullptr, 0);
@@ -95,6 +101,7 @@ void FLineRenderPass::UpdateObjectConstant(const FMatrix& WorldMatrix, const FVe
 
 void FLineRenderPass::ProcessLineRendering(const std::shared_ptr<FEditorViewportClient>& Viewport)
 {
+    UpdateShader();
     PrepareLineShader();
 
     // 상수 버퍼 업데이트: Identity 모델, 기본 색상 등

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.h
@@ -25,6 +25,7 @@ public:
 
     // 라인 렌더링 전용 함수
     void CreateShader();
+    void UpdateShader();
     void PrepareLineShader() const;
     void UpdateObjectConstant(const FMatrix& WorldMatrix, const FVector4& UUIDColor, bool bIsSelected) const;
     void ProcessLineRendering(const std::shared_ptr<FEditorViewportClient>& Viewport);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Windows/D3D11RHI/DXDShaderManager.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Windows/D3D11RHI/DXDShaderManager.cpp
@@ -58,10 +58,6 @@ void FDXDShaderManager::UpdateShaderIfOutdated(const std::wstring Key, const std
 
     if (IsVertexShader)
     {
-        // Vertex Shader Map에 존재한다면 해당 VS, Input Layout 제거
-        if (VertexShaders.Contains(Key)) { VertexShaders[Key]->Release(); VertexShaders[Key] = nullptr; }
-        if (InputLayouts.Contains(Key)) { InputLayouts[Key]->Release();    InputLayouts[Key] = nullptr; }
-
         ShaderTimeStamps[Key] = currentTime;
         (Defines)
             ? AddVertexShaderAndInputLayout(Key, FilePath, EntryPoint, Layout, LayoutSize, Defines)
@@ -69,11 +65,6 @@ void FDXDShaderManager::UpdateShaderIfOutdated(const std::wstring Key, const std
     }
     else
     {
-        // Pixel Shader Map에 존재한다면 해당 PS 제거
-        if (PixelShaders.Contains(Key)) { 
-            PixelShaders[Key]->Release();
-            PixelShaders[Key] = nullptr;
-        }
         ShaderTimeStamps[Key] = currentTime;
         (Defines)
             ? AddPixelShader(Key, FilePath, EntryPoint, Defines)
@@ -392,9 +383,12 @@ HRESULT FDXDShaderManager::AddPixelShader(const std::wstring& Key, const std::ws
     {
         RegisterShaderForReload(Key, FileName, EntryPoint, false, nullptr, nullptr, 0);
     }
+
+    // Pixel Shader Map에 존재한다면 해당 PS 제거
+    if (PixelShaders.Contains(Key)) { PixelShaders[Key]->Release();PixelShaders[Key] = nullptr; }
+
     PixelShaders[Key] = NewPixelShader;
     
-
     return S_OK;
 }
 
@@ -443,6 +437,10 @@ HRESULT FDXDShaderManager::AddPixelShader(const std::wstring& Key, const std::ws
     {
         RegisterShaderForReload(Key, FileName, EntryPoint, false, const_cast<D3D_SHADER_MACRO*>(defines), nullptr, 0);
     }
+
+    // Pixel Shader Map에 존재한다면 해당 PS 제거
+    if (PixelShaders.Contains(Key)) { PixelShaders[Key]->Release();PixelShaders[Key] = nullptr; }
+
 	PixelShaders[Key] = NewPixelShader;
 	return S_OK;
 }
@@ -580,6 +578,10 @@ HRESULT FDXDShaderManager::AddVertexShaderAndInputLayout(const std::wstring& Key
         RegisterShaderForReload(Key, FileName, EntryPoint, true, nullptr, const_cast<D3D11_INPUT_ELEMENT_DESC*>(Layout), LayoutSize);
     }
 
+    // Vertex Shader Map에 존재한다면 해당 VS, Input Layout 제거
+    if (VertexShaders.Contains(Key)) { VertexShaders[Key]->Release(); VertexShaders[Key] = nullptr; }
+    if (InputLayouts.Contains(Key)) { InputLayouts[Key]->Release();    InputLayouts[Key] = nullptr; }
+
     VertexShaders[Key] = NewVertexShader;
     InputLayouts[Key] = NewInputLayout;
 
@@ -631,6 +633,10 @@ HRESULT FDXDShaderManager::AddVertexShaderAndInputLayout(const std::wstring& Key
     {
         RegisterShaderForReload(Key, FileName, EntryPoint, true, const_cast<D3D_SHADER_MACRO*>(defines), const_cast<D3D11_INPUT_ELEMENT_DESC*>(Layout), LayoutSize);
     }
+
+    // Vertex Shader Map에 존재한다면 해당 VS, Input Layout 제거
+    if (VertexShaders.Contains(Key)) { VertexShaders[Key]->Release(); VertexShaders[Key] = nullptr; }
+    if (InputLayouts.Contains(Key)) { InputLayouts[Key]->Release();    InputLayouts[Key] = nullptr; }
 
     VertexShaders[Key] = NewVertexShader;
     InputLayouts[Key] = NewInputLayout;

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -170,6 +170,7 @@
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Engine\Source\Runtime\Core\Math\Plane.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Actors\AmbientLightActor.cpp" />
     <ClCompile Include="Engine\Source\Editor\LevelEditor\SlateAppMessageHandler.cpp" />
     <ClCompile Include="Engine\Source\Editor\LevelEditor\SLevelEditor.cpp" />
@@ -309,6 +310,7 @@
     <None Include="Shaders\VertexBillBoardShader.hlsl" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Engine\Source\Runtime\Core\Math\Plane.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Actors\AmbientLightActor.h" />
     <ClInclude Include="Engine\Source\Editor\LevelEditor\SlateAppMessageHandler.h" />
     <ClInclude Include="Engine\Source\Editor\LevelEditor\SLevelEditor.h" />

--- a/EngineSIU/EngineSIU/Saved/AutoSaves.scene
+++ b/EngineSIU/EngineSIU/Saved/AutoSaves.scene
@@ -2,85 +2,6 @@
     "Actors": [
         {
             "ActorClass": "ACube",
-            "ActorID": "ACube_91",
-            "ActorLabel": "OBJ_CUBE_91",
-            "Components": [
-                {
-                    "ComponentClass": "UStaticMeshComponent",
-                    "ComponentID": "StaticMeshComponent_0",
-                    "Properties": {
-                        "AABB_max": "X=1.000 Y=-0.000 Z=1.000",
-                        "AABB_min": "X=0.000 Y=-1.000 Z=0.000",
-                        "ComponentClass": "UStaticMeshComponent",
-                        "ComponentName": "StaticMeshComponent_0",
-                        "ComponentOwner": "ACube_91",
-                        "ComponentOwnerClass": "ACube",
-                        "RelativeLocation": "X=34.849 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=-0.000 Yaw=0.000 Roll=33.804",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "StaticMeshPath": "Contents/Cube/cube-tex.obj",
-                        "bAutoActive": "true",
-                        "bIsActive": "true",
-                        "m_Type": ""
-                    }
-                }
-            ],
-            "RootComponentID": "StaticMeshComponent_0"
-        },
-        {
-            "ActorClass": "APointLight",
-            "ActorID": "APointLight_96",
-            "ActorLabel": "OBJ_POINTLIGHT_96",
-            "Components": [
-                {
-                    "ComponentClass": "UPointLightComponent",
-                    "ComponentID": "PointLightComponent_0",
-                    "Properties": {
-                        "AABB_Max": "X=1.000 Y=1.000 Z=0.100",
-                        "AABB_Min": "X=-1.000 Y=-1.000 Z=-0.100",
-                        "Attenuation": "20.000000",
-                        "ComponentClass": "UPointLightComponent",
-                        "ComponentName": "PointLightComponent_0",
-                        "ComponentOwner": "APointLight_96",
-                        "ComponentOwnerClass": "APointLight",
-                        "Intensity": "1000.000000",
-                        "LightColor": "R=1.000 G=1.000 B=1.000 A=1.000",
-                        "Position": "X=0.000 Y=0.000 Z=0.000",
-                        "Radius": "30.000000",
-                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "Type": "1",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                },
-                {
-                    "ComponentClass": "UBillboardComponent",
-                    "ComponentID": "UBillboardComponent_0",
-                    "Properties": {
-                        "AABB_max": "X=0.000 Y=0.000 Z=0.000",
-                        "AABB_min": "X=0.000 Y=0.000 Z=0.000",
-                        "BufferKey": "Assets/Editor/Icon/PointLight_64x.png",
-                        "ComponentClass": "UBillboardComponent",
-                        "ComponentName": "UBillboardComponent_0",
-                        "ComponentOwner": "APointLight_96",
-                        "ComponentOwnerClass": "APointLight",
-                        "FinalIndexU": "0.000000",
-                        "FinalIndexV": "0.000000",
-                        "RelativeLocation": "X=0.000 Y=-14.777 Z=1.635",
-                        "RelativeRotation": "Pitch=6.200 Yaw=-6.200 Roll=19.700",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "bAutoActive": "true",
-                        "bIsActive": "true",
-                        "m_Type": "UBillboardComponent"
-                    }
-                }
-            ],
-            "RootComponentID": "UBillboardComponent_0"
-        },
-        {
-            "ActorClass": "ACube",
             "ActorID": "ACube_102",
             "ActorLabel": "OBJ_CUBE_102",
             "Components": [
@@ -88,16 +9,16 @@
                     "ComponentClass": "UStaticMeshComponent",
                     "ComponentID": "StaticMeshComponent_0",
                     "Properties": {
-                        "AABB_max": "X=1.287 Y=1.199 Z=2.555",
-                        "AABB_min": "X=-1.287 Y=-1.199 Z=-0.000",
+                        "AABB_max": "X=0.893 Y=1.666 Z=4.294",
+                        "AABB_min": "X=-0.410 Y=-1.666 Z=-0.005",
                         "ComponentClass": "UStaticMeshComponent",
                         "ComponentName": "StaticMeshComponent_0",
                         "ComponentOwner": "ACube_102",
                         "ComponentOwnerClass": "ACube",
-                        "RelativeLocation": "X=0.000 Y=-8.063 Z=3.574",
+                        "RelativeLocation": "X=0.000 Y=-6.210 Z=0.000",
                         "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
                         "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "StaticMeshPath": "Contents/Reference/Reference.obj",
+                        "StaticMeshPath": "Contents/Madara/Madara_Uchiha.obj",
                         "bAutoActive": "true",
                         "bIsActive": "true",
                         "m_Type": ""
@@ -111,6 +32,27 @@
             "ActorID": "ADirectionalLight_104",
             "ActorLabel": "OBJ_DIRECTIONALLGIHT_104",
             "Components": [
+                {
+                    "ComponentClass": "UBillboardComponent",
+                    "ComponentID": "UBillboardComponent_0",
+                    "Properties": {
+                        "AABB_max": "X=0.000 Y=0.000 Z=0.000",
+                        "AABB_min": "X=0.000 Y=0.000 Z=0.000",
+                        "BufferKey": "Assets/Editor/Icon/DirectionalLight_64x.png",
+                        "ComponentClass": "UBillboardComponent",
+                        "ComponentName": "UBillboardComponent_0",
+                        "ComponentOwner": "ADirectionalLight_104",
+                        "ComponentOwnerClass": "ADirectionalLight",
+                        "FinalIndexU": "0.000000",
+                        "FinalIndexV": "0.000000",
+                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
+                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
+                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
+                        "bAutoActive": "true",
+                        "bIsActive": "true",
+                        "m_Type": "UBillboardComponent"
+                    }
+                },
                 {
                     "ComponentClass": "UDirectionalLightComponent",
                     "ComponentID": "UDirectionalLightComponent_0",
@@ -130,30 +72,36 @@
                         "bAutoActive": "true",
                         "bIsActive": "true"
                     }
-                },
-                {
-                    "ComponentClass": "UBillboardComponent",
-                    "ComponentID": "UBillboardComponent_0",
-                    "Properties": {
-                        "AABB_max": "X=0.000 Y=0.000 Z=0.000",
-                        "AABB_min": "X=0.000 Y=0.000 Z=0.000",
-                        "BufferKey": "Assets/Editor/Icon/DirectionalLight_64x.png",
-                        "ComponentClass": "UBillboardComponent",
-                        "ComponentName": "UBillboardComponent_0",
-                        "ComponentOwner": "ADirectionalLight_104",
-                        "ComponentOwnerClass": "ADirectionalLight",
-                        "FinalIndexU": "0.000000",
-                        "FinalIndexV": "0.000000",
-                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=154.500 Yaw=-25.300 Roll=-126.900",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "bAutoActive": "true",
-                        "bIsActive": "true",
-                        "m_Type": "UBillboardComponent"
-                    }
                 }
             ],
             "RootComponentID": "UBillboardComponent_0"
+        },
+        {
+            "ActorClass": "ACube",
+            "ActorID": "ACube_107",
+            "ActorLabel": "ACube107",
+            "Components": [
+                {
+                    "ComponentClass": "UStaticMeshComponent",
+                    "ComponentID": "StaticMeshComponent_0",
+                    "Properties": {
+                        "AABB_max": "X=0.893 Y=1.666 Z=4.294",
+                        "AABB_min": "X=-0.410 Y=-1.666 Z=-0.005",
+                        "ComponentClass": "UStaticMeshComponent",
+                        "ComponentName": "StaticMeshComponent_0",
+                        "ComponentOwner": "ACube_107",
+                        "ComponentOwnerClass": "ACube",
+                        "RelativeLocation": "X=11.711 Y=5.632 Z=0.000",
+                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
+                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
+                        "StaticMeshPath": "Contents/Madara/Madara_Uchiha.obj",
+                        "bAutoActive": "true",
+                        "bIsActive": "true",
+                        "m_Type": ""
+                    }
+                }
+            ],
+            "RootComponentID": "StaticMeshComponent_0"
         }
     ],
     "NextUUID": 0,

--- a/EngineSIU/EngineSIU/Shaders/StaticMeshPixelShader.hlsl
+++ b/EngineSIU/EngineSIU/Shaders/StaticMeshPixelShader.hlsl
@@ -72,6 +72,5 @@ float4 mainPS(PS_INPUT_StaticMesh Input) : SV_Target
     {
         FinalColor += float4(0.01, 0.01, 0.0, 1);
     }
-    
     return FinalColor;
 }


### PR DESCRIPTION
이 풀 리퀘스트는 언리얼 엔진 코드베이스에 대한 여러 업데이트를 포함하며, 특히 `UObject` 및 `AActor` 클래스 개선과 저장된 씬 파일 변경에 중점을 둡니다. 이러한 변경 사항들은 컴포넌트 복제 기능을 개선하고, 오브젝트 이름 관리를 위한 새로운 메서드를 도입하며, 새로운 구성을 반영하도록 씬 에셋을 업데이트합니다.

### 코드 개선 사항

#### `UObject` 클래스 업데이트:

*   `NamePrivate` 멤버를 업데이트하는 `SetFName` 메서드를 추가하여, `FName`을 키로 사용하는 모든 컨테이너가 업데이트되도록 보장합니다.
*   `AActor`가 `UObject`의 private 멤버에 접근할 수 있도록 `AActor`를 `UObject`의 `friend` 클래스로 선언했습니다.

#### `AActor` 클래스 업데이트:

*   `AActor::Duplicate` 메서드에 로직을 도입하여, 복제 과정 중 기본 컴포넌트 이름을 임시로 저장하고 재사용함으로써 컴포넌트 이름 지정의 일관성을 보장합니다. [[관련 코드 변경 1]](diffhunk://#diff-b234557ab08609cf3b85b93702727702aa397258d04b2929f7ca67380adeb5e1R13-R19) [[관련 코드 변경 2]](diffhunk://#diff-b234557ab08609cf3b85b93702727702aa397258d04b2929f7ca67380adeb5e1L28-R46)

*  차후에 CDO나 UPROPETY로 로직을 변경해야 합니다.