### PR TITLE
[feat] HotReload 컴파일에러시 터지는 것 방지

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.cpp
@@ -132,6 +132,13 @@ void FBillboardRenderPass::CreateShader()
     PixelShader = ShaderManager->GetPixelShaderByKey(L"PixelBillboardShader");
 }
 
+void FBillboardRenderPass::UpdateShader()
+{
+    VertexShader = ShaderManager->GetVertexShaderByKey(L"VertexBillboardShader");
+    InputLayout = ShaderManager->GetInputLayoutByKey(L"VertexBillboardShader");
+    PixelShader = ShaderManager->GetPixelShaderByKey(L"PixelBillboardShader");
+}
+
 void FBillboardRenderPass::ReleaseShader()
 {
 }
@@ -142,6 +149,8 @@ void FBillboardRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& 
 
     FRenderTargetRHI* RenderTargetRHI = ViewportResource->GetRenderTarget(ResourceType);
     Graphics->DeviceContext->OMSetRenderTargets(1, &RenderTargetRHI->RTV, ViewportResource->GetDepthStencilView());
+
+    UpdateShader();
 
     PrepareTextureShader();
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.h
@@ -46,6 +46,7 @@ public:
         ID3D11ShaderResourceView* _TextureSRV, ID3D11SamplerState* _SamplerState) const;
 
     void CreateShader();
+    void UpdateShader();
     void ReleaseShader();
 
 protected:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.cpp
@@ -52,6 +52,12 @@ void FFogRenderPass::CreateShader()
     PixelShader = ShaderManager->GetPixelShaderByKey(L"FogPixelShader");
 }
 
+void FFogRenderPass::UpdateShader()
+{
+    VertexShader = ShaderManager->GetVertexShaderByKey(L"FogVertexShader");
+    PixelShader = ShaderManager->GetPixelShaderByKey(L"FogPixelShader");
+}
+
 void FFogRenderPass::ReleaseShader()
 {
 }
@@ -112,6 +118,8 @@ void FFogRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Viewpo
 
     Graphics->DeviceContext->PSSetShaderResources(static_cast<UINT>(EShaderSRVSlot::SRV_SceneDepth), 1, &ViewportResource->GetDepthStencilSRV());
     
+    UpdateShader();
+
     PrepareRenderState();
     
     for (const auto& Fog : FogComponents)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.h
@@ -28,6 +28,7 @@ public:
 
     // Fog 렌더링용 셰이더 생성 및 입력 레이아웃 설정
     void CreateShader();
+    void UpdateShader();
     void ReleaseShader();
 
     void PrepareRenderState();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.cpp
@@ -76,6 +76,13 @@ void FGizmoRenderPass::CreateShader()
     PixelShader = ShaderManager->GetPixelShaderByKey(L"GizmoPixelShader");
 }
 
+void FGizmoRenderPass::UpdateShader()
+{
+    VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+    InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+    PixelShader = ShaderManager->GetPixelShaderByKey(L"GizmoPixelShader");
+}
+
 void FGizmoRenderPass::ReleaseShader()
 {
 }
@@ -92,7 +99,7 @@ void FGizmoRenderPass::ClearRenderArr()
 void FGizmoRenderPass::PrepareRenderState() const
 {
     Graphics->DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    
+
     Graphics->DeviceContext->VSSetShader(VertexShader, nullptr, 0);
     Graphics->DeviceContext->PSSetShader(PixelShader, nullptr, 0);
     Graphics->DeviceContext->IASetInputLayout(InputLayout);
@@ -191,6 +198,8 @@ void FGizmoRenderPass::RenderGizmoComponent(UGizmoBaseComponent* GizmoComp, cons
     {
         return;
     }
+
+    UpdateShader();
 
     PrepareRenderState();
     

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.h
@@ -33,6 +33,7 @@ public:
     void RenderGizmoComponent(UGizmoBaseComponent* GizmoComp, const std::shared_ptr<FEditorViewportClient>& Viewport);
 
     void CreateShader();
+    void UpdateShader();
     void ReleaseShader();
 
     void CreateBuffer();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.cpp
@@ -57,6 +57,12 @@ void FLineRenderPass::CreateShader()
     PixelLineShader = ShaderManager->GetPixelShaderByKey(L"PixelLineShader");
 }
 
+void FLineRenderPass::UpdateShader()
+{
+    VertexLineShader = ShaderManager->GetVertexShaderByKey(L"VertexLineShader");
+    PixelLineShader = ShaderManager->GetPixelShaderByKey(L"PixelLineShader");
+}
+
 void FLineRenderPass::PrepareLineShader() const
 {
     Graphics->DeviceContext->VSSetShader(VertexLineShader, nullptr, 0);
@@ -95,6 +101,7 @@ void FLineRenderPass::UpdateObjectConstant(const FMatrix& WorldMatrix, const FVe
 
 void FLineRenderPass::ProcessLineRendering(const std::shared_ptr<FEditorViewportClient>& Viewport)
 {
+    UpdateShader();
     PrepareLineShader();
 
     // 상수 버퍼 업데이트: Identity 모델, 기본 색상 등

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.h
@@ -25,6 +25,7 @@ public:
 
     // 라인 렌더링 전용 함수
     void CreateShader();
+    void UpdateShader();
     void PrepareLineShader() const;
     void UpdateObjectConstant(const FMatrix& WorldMatrix, const FVector4& UUIDColor, bool bIsSelected) const;
     void ProcessLineRendering(const std::shared_ptr<FEditorViewportClient>& Viewport);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Windows/D3D11RHI/DXDShaderManager.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Windows/D3D11RHI/DXDShaderManager.cpp
@@ -58,10 +58,6 @@ void FDXDShaderManager::UpdateShaderIfOutdated(const std::wstring Key, const std
 
     if (IsVertexShader)
     {
-        // Vertex Shader Map에 존재한다면 해당 VS, Input Layout 제거
-        if (VertexShaders.Contains(Key)) { VertexShaders[Key]->Release(); VertexShaders[Key] = nullptr; }
-        if (InputLayouts.Contains(Key)) { InputLayouts[Key]->Release();    InputLayouts[Key] = nullptr; }
-
         ShaderTimeStamps[Key] = currentTime;
         (Defines)
             ? AddVertexShaderAndInputLayout(Key, FilePath, EntryPoint, Layout, LayoutSize, Defines)
@@ -69,11 +65,6 @@ void FDXDShaderManager::UpdateShaderIfOutdated(const std::wstring Key, const std
     }
     else
     {
-        // Pixel Shader Map에 존재한다면 해당 PS 제거
-        if (PixelShaders.Contains(Key)) { 
-            PixelShaders[Key]->Release();
-            PixelShaders[Key] = nullptr;
-        }
         ShaderTimeStamps[Key] = currentTime;
         (Defines)
             ? AddPixelShader(Key, FilePath, EntryPoint, Defines)
@@ -392,9 +383,12 @@ HRESULT FDXDShaderManager::AddPixelShader(const std::wstring& Key, const std::ws
     {
         RegisterShaderForReload(Key, FileName, EntryPoint, false, nullptr, nullptr, 0);
     }
+
+    // Pixel Shader Map에 존재한다면 해당 PS 제거
+    if (PixelShaders.Contains(Key)) { PixelShaders[Key]->Release();PixelShaders[Key] = nullptr; }
+
     PixelShaders[Key] = NewPixelShader;
     
-
     return S_OK;
 }
 
@@ -443,6 +437,10 @@ HRESULT FDXDShaderManager::AddPixelShader(const std::wstring& Key, const std::ws
     {
         RegisterShaderForReload(Key, FileName, EntryPoint, false, const_cast<D3D_SHADER_MACRO*>(defines), nullptr, 0);
     }
+
+    // Pixel Shader Map에 존재한다면 해당 PS 제거
+    if (PixelShaders.Contains(Key)) { PixelShaders[Key]->Release();PixelShaders[Key] = nullptr; }
+
 	PixelShaders[Key] = NewPixelShader;
 	return S_OK;
 }
@@ -580,6 +578,10 @@ HRESULT FDXDShaderManager::AddVertexShaderAndInputLayout(const std::wstring& Key
         RegisterShaderForReload(Key, FileName, EntryPoint, true, nullptr, const_cast<D3D11_INPUT_ELEMENT_DESC*>(Layout), LayoutSize);
     }
 
+    // Vertex Shader Map에 존재한다면 해당 VS, Input Layout 제거
+    if (VertexShaders.Contains(Key)) { VertexShaders[Key]->Release(); VertexShaders[Key] = nullptr; }
+    if (InputLayouts.Contains(Key)) { InputLayouts[Key]->Release();    InputLayouts[Key] = nullptr; }
+
     VertexShaders[Key] = NewVertexShader;
     InputLayouts[Key] = NewInputLayout;
 
@@ -631,6 +633,10 @@ HRESULT FDXDShaderManager::AddVertexShaderAndInputLayout(const std::wstring& Key
     {
         RegisterShaderForReload(Key, FileName, EntryPoint, true, const_cast<D3D_SHADER_MACRO*>(defines), const_cast<D3D11_INPUT_ELEMENT_DESC*>(Layout), LayoutSize);
     }
+
+    // Vertex Shader Map에 존재한다면 해당 VS, Input Layout 제거
+    if (VertexShaders.Contains(Key)) { VertexShaders[Key]->Release(); VertexShaders[Key] = nullptr; }
+    if (InputLayouts.Contains(Key)) { InputLayouts[Key]->Release();    InputLayouts[Key] = nullptr; }
 
     VertexShaders[Key] = NewVertexShader;
     InputLayouts[Key] = NewInputLayout;


### PR DESCRIPTION
## 주요 변경사항

1.  Shader컴파일에러시에 프로그램이 터지는 것을 방지했습니다.
AddVertexShader함수에 error분기문을 모두 통과해야 release하는 것으로 변경했습니다.
![image](https://github.com/user-attachments/assets/7c3b34f2-134b-45b0-95e2-d6f2c0a47b86)
error가 생겼을시, shader에서만 compile error를 뱉고, 에디터 프로그램에는 영향을 주지 않습니다.

2. StaticMeshVertex,PixelShader 제외한 다른 Shader변경시 터지는 버그 방지
다른 Shader의 경우 HotReload상태에서 Release할 경우, 기존 VertexShader, PixelShader에 Get으로 바인딩해주지 않고 있었습니다.
RenderPass에 UpdateShader()함수를 통해 매번 바인딩하는 것으로 수정했습니다.
